### PR TITLE
On Precompile, transpile .es6 (ES6) extension to .js (ES5) by gem spr…

### DIFF
--- a/lib/requirejs/rails/config.rb
+++ b/lib/requirejs/rails/config.rb
@@ -16,6 +16,7 @@ module Requirejs
       LOGICAL_PATH_PATTERNS = [
           Regexp.new("\\.html\\z"),
           Regexp.new("\\.js\\z"),
+          Regexp.new("\\.es6\\z"),
           Regexp.new("\\.txt\\z"),
           BOWER_PATH_PATTERN
       ]

--- a/lib/tasks/requirejs-rails_tasks.rake
+++ b/lib/tasks/requirejs-rails_tasks.rake
@@ -98,10 +98,16 @@ OS X Homebrew users can use 'brew install node'.
 
       requirejs.env.each_logical_path(requirejs.config.logical_path_patterns) do |logical_path|
         m = ::Requirejs::Rails::Config::BOWER_PATH_PATTERN.match(logical_path)
-
         if !m
+          
+          # if file extension is .es6, change logical path extension to .js
+          check_extension = logical_path.split(".")
+          if check_extension[check_extension.length-1] == "es6"
+            check_extension[check_extension.length-1] = "js"
+            logical_path = check_extension.join(".")
+          end
+          
           asset = requirejs.env.find_asset(logical_path)
-
           if asset
             file = requirejs.config.source_dir.join(asset.logical_path)
             file.dirname.mkpath


### PR DESCRIPTION
…ockets-es6
- Add .es6 extension to logical path patterns
- Update requirejs-rails_tasks.rake
- Change .es6 file extension logical path to .js
